### PR TITLE
Support arm64 architecture name

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -41,7 +41,7 @@ function get_platform() {
 function get_arch() {
   case "$(uname -m)" in
     x86_64) echo -n "x64" ;;
-    aarch64) echo -n "aarch64" ;;
+    aarch64|arm64) echo -n "aarch64" ;;
     *) fail "Unsupported architecture" ;;
   esac
 }


### PR DESCRIPTION
On macOS and some Linux, the architecture name is output as `arm64`.

```shell-session
$ uname -m
arm64
```

ref. https://github.com/Jarred-Sumner/bun/blob/ee83e25120f8ff52fb44d83ac25b965c2cc2b062/src/cli/install.sh#L41-L48