### PR TITLE
Fix fail function output to STDERR

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -70,6 +70,6 @@ function get_temp_dir() {
 }
 
 function fail() {
-  echo -e "\e[31mFail:\e[m $*"
+  echo -e "\e[31mFail:\e[m $*" 1>&2
   exit 1
 }


### PR DESCRIPTION
If error messages are output to standard output, nothing is output when command substitution is used.
Therefore, we do not know why the script terminated abnormally.

```bash
arch=$(get_arch)
# => When an error occurs in `get_arch` function, `fail` function is called and the script exits,
#    but nothing is output because the output is directed to variable assignments.
```