### PR TITLE
fix: mktemp for alpine

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -83,7 +83,7 @@ function get_temp_dir() {
   base="${base%/}"
 
   local tmpdir
-  tmpdir=$(mktemp -d "$base/asdf-bun.XXXX")
+  tmpdir=$(mktemp -d "$base/asdf-bun.XXXXXX")
 
   echo -n "$tmpdir"
 }


### PR DESCRIPTION
The previous code used a template with four X’s (XXXX) in the mktemp command:

```bash
mktemp -d "$base/asdf-bun.XXXX"
```

This works on Ubuntu (GNU coreutils) but fails on Alpine Linux (BusyBox) with the error:

```shell
mktemp: : Invalid argument
```

This is because BusyBox requires the template to end with exactly six X’s (XXXXXX), while GNU coreutils is more lenient.

This PR updates to using six `X`'s, which is compatible with both versions of `mktemp`.